### PR TITLE
fix loading by adding modules to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,9 +21,12 @@ Imports:
   prophet,
   BART,
   EBMAforecast,
-  imputeTS
+  imputeTS,
+  scoringRules,
+  scoringutils
 Suggests:
   testthat
 Remotes:
   jasp-stats/jaspBase,
-  jasp-stats/jaspGraphs
+  jasp-stats/jaspGraphs,
+  epiforecasts/scoringutils@v1.2.2


### PR DESCRIPTION
Some modules were missing from the DESCRIPTION file and thus installed, which made the module failed. 
The scoringutils package was also rewritten which broke parts of the analysis. For now the older version is loaded instead.

@RensDofferhoff could you please update the renv lockfile for me as you suggested? :)
Thank you!